### PR TITLE
AEGIS-58 Create a new temporary file playground session

### DIFF
--- a/src/main/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundSession.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundSession.java
@@ -1,0 +1,37 @@
+package atlanteshellsing.aegis.fileplayground.model;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Immutable data for a Temporary File Playground Session.
+ */
+public record TemporaryFilePlaygroundSession(
+        UUID id,
+        Path workspacePath,
+        Instant createdAt,
+        TemporaryFilePlaygroundState state
+) {
+
+    public TemporaryFilePlaygroundSession {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(workspacePath, "workspacePath cannot be null");
+        Objects.requireNonNull(createdAt, "createdAt cannot be null");
+        Objects.requireNonNull(state, "state cannot be null");
+    }
+
+    public boolean isOpen() {
+        return state == TemporaryFilePlaygroundState.OPEN;
+    }
+
+    public TemporaryFilePlaygroundSession asClosed() {
+        return new TemporaryFilePlaygroundSession(
+                id,
+                workspacePath,
+                createdAt,
+                TemporaryFilePlaygroundState.CLOSED
+        );
+    }
+}

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundState.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundState.java
@@ -1,0 +1,12 @@
+package atlanteshellsing.aegis.fileplayground.model;
+
+import atlanteshellsing.aegis.annotations.ExcludeAsGenerated;
+
+/**
+ * Represents the lifecycle state of a Temporary File Playground Session.
+ */
+@ExcludeAsGenerated
+public enum TemporaryFilePlaygroundState {
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
@@ -4,6 +4,7 @@ import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundSessio
 import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundState;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -20,7 +21,7 @@ import java.util.*;import java.util.stream.Collectors;
 public class AEGISTemporaryFilePlaygroundManager {
 
     private final Path playgroundRoot;
-    public final Map<UUID, TemporaryFilePlaygroundSession> sessions;
+    private final Map<UUID, TemporaryFilePlaygroundSession> sessions;
 
     /**
      * Creates a manager using the provided playground root.
@@ -48,9 +49,11 @@ public class AEGISTemporaryFilePlaygroundManager {
                 String sessionId = UUID.randomUUID().toString();
                 Path sessionPath = playgroundRoot.resolve(sessionId);
 
-                if(Files.exists(sessionPath)) {
-                    continue;
-                }
+               try {
+                   Files.createDirectory(sessionPath);
+               } catch (FileAlreadyExistsException e) {
+                   continue;
+               }
 
                 Files.createDirectory(sessionPath);
 

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
@@ -1,0 +1,119 @@
+package atlanteshellsing.aegis.fileplayground.service;
+
+import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundSession;
+import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundState;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.*;import java.util.stream.Collectors;
+
+/**
+ * Manages Temporary File Playground sessions for the current application run.
+ *
+ * Current behavior:
+ * - Creates session folders under the configured playground root
+ * - Tracks session metadata in memory
+ * - Allows multiple playground sessions to remain open at once
+ */
+public class AEGISTemporaryFilePlaygroundManager {
+
+    private final Path playgroundRoot;
+    public final Map<UUID, TemporaryFilePlaygroundSession> sessions;
+
+    /**
+     * Creates a manager using the provided playground root.
+     *
+     * @param playgroundRoot root directory for all Temporary File Playground sessions
+     */
+    public AEGISTemporaryFilePlaygroundManager(Path playgroundRoot) {
+        this.playgroundRoot = Objects.requireNonNull(playgroundRoot, "playgroundRoot cannot be null")
+                .toAbsolutePath()
+                .normalize();
+        this.sessions = new LinkedHashMap<>();
+    }
+
+    /**
+     * Creates a new Temporary File Playground session.
+     *
+     * @return metadata for the created session
+     * @throws IllegalStateException if the session directory cannot be created
+     */
+    public synchronized TemporaryFilePlaygroundSession createSession() {
+        try {
+            Files.createDirectories(playgroundRoot);
+
+            while(true) {
+                String sessionId = UUID.randomUUID().toString();
+                Path sessionPath = playgroundRoot.resolve(sessionId);
+
+                if(Files.exists(sessionPath)) {
+                    continue;
+                }
+
+                Files.createDirectory(sessionPath);
+
+                TemporaryFilePlaygroundSession session = new TemporaryFilePlaygroundSession(
+                        UUID.fromString(sessionId),
+                        sessionPath.toAbsolutePath().normalize(),
+                        Instant.now(),
+                        TemporaryFilePlaygroundState.OPEN
+                );
+
+                sessions.put(session.id(), session);
+                return session;
+
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create temporary file playground session", e);
+        }
+    }
+
+    /**
+     * Returns a tracked session by ID, or null if not found.
+     *
+     * @param sessionId the session ID
+     * @return the session or null
+     */
+    public synchronized TemporaryFilePlaygroundSession getSession(UUID sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId cannot be null");
+        return sessions.get(sessionId);
+    }
+
+    /**
+     * Returns all sessions tracked during the current run.
+     *
+     * @return unmodifiable snapshot of tracked sessions
+     */
+    public synchronized Map<UUID, TemporaryFilePlaygroundSession> getAllSessions() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(sessions));
+    }
+
+    /**
+     * Returns all currently open sessions tracked during the current run.
+     *
+     * @return unmodifiable snapshot of open sessions
+     */
+    public synchronized Map<UUID, TemporaryFilePlaygroundSession> getOpenSessions() {
+        return Collections.unmodifiableMap(
+                sessions.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().isOpen())
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (e1, e2) -> e1,
+                                LinkedHashMap::new
+                        ))
+        );
+    }
+
+    /**
+     * Returns the normalized absolute playground root path.
+     *
+     * @return playground root
+     */
+    public Path getPlaygroundRoot() { return playgroundRoot; }
+
+}

--- a/src/test/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundSessionTest.java
+++ b/src/test/java/atlanteshellsing/aegis/fileplayground/model/TemporaryFilePlaygroundSessionTest.java
@@ -1,0 +1,101 @@
+package atlanteshellsing.aegis.fileplayground.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TemporaryFilePlaygroundSessionTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void isOpenShouldReturnTrueWhenStateIsOpen() {
+        TemporaryFilePlaygroundSession session = new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                tempDir.resolve("workspace"),
+                Instant.now(),
+                TemporaryFilePlaygroundState.OPEN
+        );
+
+        assertTrue(session.isOpen());
+    }
+
+    @Test
+    void isOpenShouldReturnFalseWhenStateIsClosed() {
+        TemporaryFilePlaygroundSession session = new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                tempDir.resolve("workspace"),
+                Instant.now(),
+                TemporaryFilePlaygroundState.CLOSED
+        );
+
+        assertFalse(session.isOpen());
+    }
+
+    @Test
+    void asClosedShouldReturnClosedCopy() {
+        TemporaryFilePlaygroundSession session = new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                tempDir.resolve("workspace"),
+                Instant.now(),
+                TemporaryFilePlaygroundState.OPEN
+        );
+
+        TemporaryFilePlaygroundSession closed = session.asClosed();
+
+        assertEquals(session.id(), closed.id());
+        assertEquals(session.workspacePath(), closed.workspacePath());
+        assertEquals(session.createdAt(), closed.createdAt());
+        assertEquals(TemporaryFilePlaygroundState.CLOSED, closed.state());
+        assertFalse(closed.isOpen());
+    }
+
+    @Test
+    void constructorShouldRejectNullId() {
+        assertThrows(NullPointerException.class, () -> new TemporaryFilePlaygroundSession(
+                null,
+                tempDir.resolve("workspace"),
+                Instant.now(),
+                TemporaryFilePlaygroundState.OPEN
+        ));
+    }
+
+    @Test
+    void constructorShouldRejectNullWorkspacePath() {
+        assertThrows(NullPointerException.class, () -> new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                null,
+                Instant.now(),
+                TemporaryFilePlaygroundState.OPEN
+        ));
+    }
+
+    @Test
+    void constructorShouldRejectNullCreatedAt() {
+        assertThrows(NullPointerException.class, () -> new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                tempDir.resolve("workspace"),
+                null,
+                TemporaryFilePlaygroundState.OPEN
+        ));
+    }
+
+    @Test
+    void constructorShouldRejectNullState() {
+        assertThrows(NullPointerException.class, () -> new TemporaryFilePlaygroundSession(
+                UUID.randomUUID(),
+                tempDir.resolve("workspace"),
+                Instant.now(),
+                null
+        ));
+    }
+}

--- a/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
+++ b/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
@@ -1,0 +1,124 @@
+package atlanteshellsing.aegis.fileplayground.service;
+
+import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundSession;
+import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundState;
+import atlanteshellsing.aegis.fileplayground.service.AEGISTemporaryFilePlaygroundManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AEGISTemporaryFilePlaygroundManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createSessionShouldCreateUniqueSessionFoldersAndTrackMetadata() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        TemporaryFilePlaygroundSession first = manager.createSession();
+        TemporaryFilePlaygroundSession second = manager.createSession();
+
+        assertNotNull(first);
+        assertNotNull(second);
+
+        assertNotNull(first.id());
+        assertNotNull(second.id());
+        assertNotNull(first.workspacePath());
+        assertNotNull(second.workspacePath());
+        assertNotNull(first.createdAt());
+        assertNotNull(second.createdAt());
+
+        assertEquals(TemporaryFilePlaygroundState.OPEN, first.state());
+        assertEquals(TemporaryFilePlaygroundState.OPEN, second.state());
+
+        assertTrue(first.isOpen());
+        assertTrue(second.isOpen());
+
+        assertNotEquals(first.id(), second.id());
+        assertNotEquals(first.workspacePath(), second.workspacePath());
+
+        assertTrue(Files.isDirectory(first.workspacePath()));
+        assertTrue(Files.isDirectory(second.workspacePath()));
+
+        assertEquals(root.toAbsolutePath().normalize(), first.workspacePath().getParent());
+        assertEquals(root.toAbsolutePath().normalize(), second.workspacePath().getParent());
+
+        assertEquals(2, manager.getAllSessions().size());
+        assertEquals(2, manager.getOpenSessions().size());
+
+        assertEquals(TemporaryFilePlaygroundState.OPEN, manager.getAllSessions().get(first.id()).state());
+        assertEquals(TemporaryFilePlaygroundState.OPEN, manager.getAllSessions().get(second.id()).state());
+    }
+
+    @Test
+    void getSessionShouldReturnTrackedSession() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        TemporaryFilePlaygroundSession created = manager.createSession();
+        TemporaryFilePlaygroundSession retrieved = manager.getSession(created.id());
+
+        assertNotNull(retrieved);
+        assertEquals(created.id(), retrieved.id());
+        assertEquals(created.workspacePath(), retrieved.workspacePath());
+        assertEquals(created.createdAt(), retrieved.createdAt());
+        assertEquals(created.state(), retrieved.state());
+    }
+
+    @Test
+    void getAllSessionsShouldReturnEmptyMapBeforeAnySessionIsCreated() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        assertTrue(manager.getAllSessions().isEmpty());
+        assertTrue(manager.getOpenSessions().isEmpty());
+    }
+
+    @Test
+    void getAllSessionsShouldReturnUnmodifiableMap() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        manager.createSession();
+
+        Map<java.util.UUID, TemporaryFilePlaygroundSession> sessions = manager.getAllSessions();
+
+        assertThrows(UnsupportedOperationException.class, sessions::clear);
+    }
+
+    @Test
+    void getOpenSessionsShouldReturnUnmodifiableMap() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        manager.createSession();
+
+        Map<java.util.UUID, TemporaryFilePlaygroundSession> sessions = manager.getOpenSessions();
+
+        assertThrows(UnsupportedOperationException.class, sessions::clear);
+    }
+
+    @Test
+    void constructorShouldNormalizePlaygroundRoot() {
+        Path root = tempDir.resolve("AEGIS")
+                .resolve("temp")
+                .resolve("..")
+                .resolve("temp")
+                .resolve("file-playground");
+
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+
+        assertEquals(root.toAbsolutePath().normalize(), manager.getPlaygroundRoot());
+    }
+}


### PR DESCRIPTION
C-1: Created framework for sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added temporary file playground session management system enabling creation, tracking, and state management of sessions.
  * Sessions support open/closed state transitions and can be queried individually or as collections.
  * Implemented thread-safe session operations.

* **Tests**
  * Added comprehensive test coverage for session management and lifecycle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->