### PR TITLE
AEGIS-60 Add drag-and-drop file and folder import

### DIFF
--- a/src/main/java/atlanteshellsing/aegis/fileplayground/gui/TemporaryFilePlaygroundPanel.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/gui/TemporaryFilePlaygroundPanel.java
@@ -8,11 +8,11 @@ import atlanteshellsing.aegis.threading.AEGISThreadManager;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.control.*;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -36,6 +35,10 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
     private final TreeView<WorkspaceTreeEntry> treeView;
     private final Label emptyStateLabel;
     private final AtomicLong refreshRequestId;
+    private Region workspaceDropTarget;
+    private static final String TEMPORARY_FILE_PLAYGROUND = "Temporary File Playground";
+    private static final String DROP_IDLE_STYLE = "";
+    private static final String DROP_ACTIVE_STYLE = "-fx-border-color: #4DA3FF; -fx-border-width: 2; -fx-border-radius: 6; -fx-background-color: rgba(77, 163, 255, 0.10);";
 
     /**
      * Create a panel bound to an existing Temporary File Playground session.
@@ -62,7 +65,7 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
     }
 
     private VBox buildHeader() {
-        Label title = new Label("Temporary File Playground");
+        Label title = new Label(TEMPORARY_FILE_PLAYGROUND);
         title.setStyle("-fx-font-size: 16px; -fx-font-weight: bold;");
 
         Label temporaryNotice = new Label("Temporary Workspace: Files in this session are not permanent.");
@@ -99,6 +102,8 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
 
         VBox container = new VBox(8, treeView, emptyStateLabel);
         VBox.setVgrow(treeView, Priority.ALWAYS);
+        workspaceDropTarget = container;
+        installDragandDropHandlers(container);
         return container;
     }
 
@@ -123,7 +128,7 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
 
     private void onCreateFileRequested() {
         TextInputDialog dialog = new TextInputDialog();
-        dialog.setTitle("Temporary File Playground");
+        dialog.setTitle(TEMPORARY_FILE_PLAYGROUND);
         dialog.setHeaderText("Create New File");
         dialog.setContentText("File Name:");
 
@@ -145,7 +150,7 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
 
     private void onCreateFolderRequested() {
         TextInputDialog dialog = new TextInputDialog();
-        dialog.setTitle("Temporary File Playground");
+        dialog.setTitle(TEMPORARY_FILE_PLAYGROUND);
         dialog.setHeaderText("Create New Folder");
         dialog.setContentText("Folder name:");
 
@@ -167,10 +172,76 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
 
     private void showErrorAlert(String title, String message) {
         Alert alert = new Alert(Alert.AlertType.ERROR);
-        alert.setTitle("Temporary File Playground");
+        alert.setTitle(TEMPORARY_FILE_PLAYGROUND);
         alert.setHeaderText(title);
         alert.setContentText(message);
         alert.showAndWait();
+    }
+
+    private void installDragandDropHandlers(Region dropTarget) {
+        dropTarget.setOnDragOver(event -> {
+           if(event.getDragboard().hasFiles()) {
+               event.acceptTransferModes(TransferMode.COPY);
+               dropTarget.setStyle(DROP_ACTIVE_STYLE);
+           }
+           event.consume();
+        });
+
+        dropTarget.setOnDragEntered(event -> {
+           if(event.getDragboard().hasFiles()) dropTarget.setStyle(DROP_ACTIVE_STYLE);
+           event.consume();
+        });
+
+        dropTarget.setOnDragExited(event -> {
+           dropTarget.setStyle(DROP_IDLE_STYLE);
+           event.consume();
+        });
+
+        dropTarget.setOnDragDropped(this::handleDrop);
+    }
+
+    private void handleDrop(DragEvent event) {
+        boolean dropComplete = false;
+        try {
+            if(event.getDragboard().hasFiles()) {
+                List<Path> paths = event.getDragboard()
+                        .getFiles()
+                        .stream()
+                        .map(File::toPath)
+                        .toList();
+
+                manager.importPaths(session.id(), paths);
+                refreshContents();
+                dropComplete = true;
+            }
+        } catch (IllegalArgumentException e) {
+            AEGISLogger.log(
+                    AEGISLogger.AEGISLogKey.AEGIS_TOOL,
+                    AEGISLogger.AEGISLogLevel.WARNING,
+                    "Failed to import dropped items in Temporary File Playground for session " + session.id(),
+                    e
+            );
+            showErrorAlert("Cannot Import Items", friendlyImportMessage(e));
+        } catch (IllegalStateException e) {
+            AEGISLogger.log(
+                    AEGISLogger.AEGISLogKey.AEGIS_TOOL,
+                    AEGISLogger.AEGISLogLevel.WARNING,
+                    "Failed to copy dropped items into Temporary File Playground for session " + session.id(),
+                    e
+            );
+            showErrorAlert("Cannot Import Items", "Unable to copy one or more dropped items right now.");
+        } finally {
+            if(workspaceDropTarget != null) workspaceDropTarget.setStyle(DROP_IDLE_STYLE);
+            event.setDropCompleted(dropComplete);
+            event.consume();
+        }
+    }
+
+    private String friendlyImportMessage(IllegalArgumentException e) {
+        String message = e.getMessage();
+        if(message == null || message.isBlank()) return "Unable to import the dropped items.";
+        if(message.contains("already exists")) return message;
+        return "Unable to import the dropped items. Please verify they are valid files/folders.";
     }
 
     private Path getSelectedTargetDirectory() {

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/gui/TemporaryFilePlaygroundPanel.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/gui/TemporaryFilePlaygroundPanel.java
@@ -201,19 +201,41 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
     }
 
     private void handleDrop(DragEvent event) {
-        boolean dropComplete = false;
+        boolean dropAccepted = false;
         try {
+
             if(event.getDragboard().hasFiles()) {
-                List<Path> paths = event.getDragboard()
-                        .getFiles()
+                List<Path> paths = event.getDragboard().getFiles()
                         .stream()
                         .map(File::toPath)
                         .toList();
 
-                manager.importPaths(session.id(), paths);
-                refreshContents();
-                dropComplete = true;
+                dropAccepted = true;
+                AEGISThreadManager.submitAsyncTask(
+                "temporary-playground-import-" + session.id(),
+                        () -> importDroppedPaths(paths),
+                TemporaryFilePlaygroundPanel.this.getClass().getSimpleName(),
+                AEGISThreadManager.PoolType.IO_BOUND);
             }
+        } catch (RuntimeException e) {
+            AEGISLogger.log(
+                    AEGISLogger.AEGISLogKey.AEGIS_TOOL,
+                    AEGISLogger.AEGISLogLevel.WARNING,
+                    "Failed to queue dropped item import in Temporary File Playground for session " + session.id(),
+                    e
+            );
+            showErrorAlert("Cannot Import Items", "Unable to start the import right now.");
+        } finally {
+            if(workspaceDropTarget != null)  workspaceDropTarget.setStyle(DROP_IDLE_STYLE);
+            event.setDropCompleted(dropAccepted);
+            event.consume();
+        }
+    }
+
+    private void importDroppedPaths(List<Path> paths) {
+        try {
+            manager.importPaths(session.id(), paths);
+            Platform.runLater(this::refreshContents);
         } catch (IllegalArgumentException e) {
             AEGISLogger.log(
                     AEGISLogger.AEGISLogKey.AEGIS_TOOL,
@@ -221,7 +243,7 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
                     "Failed to import dropped items in Temporary File Playground for session " + session.id(),
                     e
             );
-            showErrorAlert("Cannot Import Items", friendlyImportMessage(e));
+            Platform.runLater(() -> showErrorAlert("Cannot Import Items", friendlyImportMessage(e)));
         } catch (IllegalStateException e) {
             AEGISLogger.log(
                     AEGISLogger.AEGISLogKey.AEGIS_TOOL,
@@ -229,11 +251,7 @@ public class TemporaryFilePlaygroundPanel extends BorderPane {
                     "Failed to copy dropped items into Temporary File Playground for session " + session.id(),
                     e
             );
-            showErrorAlert("Cannot Import Items", "Unable to copy one or more dropped items right now.");
-        } finally {
-            if(workspaceDropTarget != null) workspaceDropTarget.setStyle(DROP_IDLE_STYLE);
-            event.setDropCompleted(dropComplete);
-            event.consume();
+            Platform.runLater(() -> showErrorAlert("Cannot Import Items", "Unable to copy one or more dropped items right now."));
         }
     }
 

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
@@ -185,21 +185,37 @@ public class AEGISTemporaryFilePlaygroundManager {
         }
 
         Path workspacePath = session.workspacePath();
+        List<ImportPlan> importPlans = new ArrayList<>();
+        Set<Path> plannedTargets = new HashSet<>();
+
         for(Path path : paths) {
+
             if(path == null) throw new  IllegalArgumentException("Dropped Item cannot be null.");
 
             Path normalizedPath = path.toAbsolutePath().normalize();
             Path fileName = normalizedPath.getFileName();
+
             if(fileName == null) throw new  IllegalArgumentException("Dropped Item has no valid name" + normalizedPath);
             if(!Files.exists(normalizedPath)) throw new IllegalArgumentException("Dropped Item does not exist: " + normalizedPath);
 
             Path targetPath = workspacePath.resolve(fileName).normalize();
-            if(Files.exists(targetPath)) throw new IllegalArgumentException("Dropped Item already exists: " + targetPath);
 
+            if(Files.isDirectory(normalizedPath) && targetPath.toAbsolutePath().normalize().startsWith(normalizedPath)) {
+                throw new IllegalArgumentException("Dropped folder cannot be imported into itself: " + normalizedPath);
+            }
+
+            if(!plannedTargets.add(targetPath)) {
+                throw new IllegalArgumentException("Dropped Item already exists: " + targetPath);
+            }
+
+            if(Files.exists(targetPath)) throw new IllegalArgumentException("Dropped Item already exists: " + targetPath);
+            importPlans.add(new ImportPlan(normalizedPath, targetPath, fileName));
+        }
+        for(ImportPlan importPlan : importPlans) {
             try {
-                copyPath(normalizedPath, targetPath);
+                copyPath(importPlan.source(), importPlan.target());
             } catch (IOException e) {
-                throw new IllegalStateException("Unable to import '" + fileName + "' into workspace" , e);
+                throw new IllegalStateException("Unable to import '" + importPlan.fileName() + "' into workspace" , e);
             }
         }
     }
@@ -263,4 +279,5 @@ public class AEGISTemporaryFilePlaygroundManager {
      * @return playground root
      */
     public Path getPlaygroundRoot() { return playgroundRoot; }
+    private record ImportPlan(Path source, Path target, Path fileName) { }
 }

--- a/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
+++ b/src/main/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManager.java
@@ -4,9 +4,8 @@ import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundSessio
 import atlanteshellsing.aegis.fileplayground.model.TemporaryFilePlaygroundState;
 
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.util.*;import java.util.stream.Collectors;
 
@@ -172,6 +171,39 @@ public class AEGISTemporaryFilePlaygroundManager {
         }
     }
 
+    /**
+     * Imports dropped files/folders into the session workspace.
+     *
+     * @param sessionId   target session
+     * @param paths dropped files/folders to copy
+     */
+    public synchronized void importPaths(UUID sessionId, List<Path> paths) {
+        TemporaryFilePlaygroundSession session = getSession(sessionId);
+
+        if(paths == null || paths.isEmpty()) {
+            throw new IllegalArgumentException("No Files or Folders to import.");
+        }
+
+        Path workspacePath = session.workspacePath();
+        for(Path path : paths) {
+            if(path == null) throw new  IllegalArgumentException("Dropped Item cannot be null.");
+
+            Path normalizedPath = path.toAbsolutePath().normalize();
+            Path fileName = normalizedPath.getFileName();
+            if(fileName == null) throw new  IllegalArgumentException("Dropped Item has no valid name" + normalizedPath);
+            if(!Files.exists(normalizedPath)) throw new IllegalArgumentException("Dropped Item does not exist: " + normalizedPath);
+
+            Path targetPath = workspacePath.resolve(fileName).normalize();
+            if(Files.exists(targetPath)) throw new IllegalArgumentException("Dropped Item already exists: " + targetPath);
+
+            try {
+                copyPath(normalizedPath, targetPath);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to import '" + fileName + "' into workspace" , e);
+            }
+        }
+    }
+
     private String validateChildName(Path workspacePath, String value, String fieldName) {
         if(value == null) throw new IllegalArgumentException(fieldName + " cannot be null");
 
@@ -196,6 +228,33 @@ public class AEGISTemporaryFilePlaygroundManager {
         if(!Files.exists(candidate) || !Files.isDirectory(candidate)) throw new IllegalArgumentException("Target directory does not exist or is not a directory");
 
         return candidate;
+    }
+
+    private void copyPath(Path source, Path target) throws IOException {
+        if(Files.isDirectory(source)) {
+            Files.walkFileTree(source, new SimpleFileVisitor<>() {
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    Path relative = source.relativize(dir);
+                    Path destination = target.resolve(relative);
+                    Files.copy(dir, destination, StandardCopyOption.COPY_ATTRIBUTES);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Path relative = source.relativize(file);
+                    Path destination = target.resolve(relative);
+                    Files.copy(file, destination, StandardCopyOption.COPY_ATTRIBUTES);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            return;
+        }
+
+        Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
     }
 
     /**

--- a/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
+++ b/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -223,5 +224,95 @@ class AEGISTemporaryFilePlaygroundManagerTest {
                 () -> manager.createFolder(session.id(), outside, "docs"));
 
         assertEquals("Target directory must be inside the workspace", exception.getMessage());
+    }
+
+    @Test
+    void importPathsShouldImportSingleFileSuccessfully() throws Exception {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        TemporaryFilePlaygroundSession session = manager.createSession();
+        Path source = tempDir.resolve("single.txt");
+        Files.writeString(source, "hello");
+
+        manager.importPaths(session.id(), List.of(source));
+
+        Path imported = session.workspacePath().resolve("single.txt");
+        assertTrue(Files.isRegularFile(imported));
+        assertEquals("hello", Files.readString(imported));
+    }
+
+    @Test
+    void importPathsShouldImportMultipleFilesSuccessfully() throws Exception {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        TemporaryFilePlaygroundSession session = manager.createSession();
+        Path first = tempDir.resolve("one.txt");
+        Path second = tempDir.resolve("two.txt");
+        Files.writeString(first, "first");
+        Files.writeString(second, "second");
+
+        manager.importPaths(session.id(), List.of(first, second));
+
+        assertEquals("first", Files.readString(session.workspacePath().resolve("one.txt")));
+        assertEquals("second", Files.readString(session.workspacePath().resolve("two.txt")));
+    }
+
+    @Test
+    void importPathsShouldImportFolderRecursivelySuccessfully() throws Exception {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        TemporaryFilePlaygroundSession session = manager.createSession();
+        Path sourceFolder = tempDir.resolve("folderA");
+        Path nested = sourceFolder.resolve("nested");
+        Files.createDirectories(nested);
+        Files.writeString(sourceFolder.resolve("root.txt"), "root");
+        Files.writeString(nested.resolve("deep.txt"), "deep");
+
+        manager.importPaths(session.id(), List.of(sourceFolder));
+
+        Path importedFolder = session.workspacePath().resolve("folderA");
+        assertTrue(Files.isDirectory(importedFolder));
+        assertEquals("root", Files.readString(importedFolder.resolve("root.txt")));
+        assertEquals("deep", Files.readString(importedFolder.resolve("nested/deep.txt")));
+    }
+
+    @Test
+    void importPathsShouldRejectDuplicateTargetName() throws Exception {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        TemporaryFilePlaygroundSession session = manager.createSession();
+        Files.writeString(session.workspacePath().resolve("dupe.txt"), "existing");
+        Path source = tempDir.resolve("dupe.txt");
+        Files.writeString(source, "new");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> manager.importPaths(session.id(), List.of(source)));
+
+        assertEquals("Dropped Item already exists: " + session.workspacePath() + "\\dupe.txt", exception.getMessage());
+    }
+
+    @Test
+    void importPathsShouldRejectUnknownSessionId() throws Exception {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        Path source = tempDir.resolve("single.txt");
+        Files.writeString(source, "hello");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> manager.importPaths(UUID.randomUUID(), List.of(source)));
+
+        assertTrue(exception.getMessage().startsWith("Temporary playground session not found:"));
+    }
+
+    @Test
+    void importPathsShouldRejectEmptyImportList() {
+        Path root = tempDir.resolve("AEGIS/temp/file-playground");
+        AEGISTemporaryFilePlaygroundManager manager = new AEGISTemporaryFilePlaygroundManager(root);
+        TemporaryFilePlaygroundSession session = manager.createSession();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> manager.importPaths(session.id(), List.of()));
+
+        assertEquals("No Files or Folders to import.", exception.getMessage());
     }
 }

--- a/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
+++ b/src/test/java/atlanteshellsing/aegis/fileplayground/service/AEGISTemporaryFilePlaygroundManagerTest.java
@@ -288,7 +288,8 @@ class AEGISTemporaryFilePlaygroundManagerTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> manager.importPaths(session.id(), List.of(source)));
 
-        assertEquals("Dropped Item already exists: " + session.workspacePath() + "\\dupe.txt", exception.getMessage());
+        Path expectedTarget = session.workspacePath().resolve("dupe.txt").normalize();
+        assertEquals("Dropped Item already exists: " + expectedTarget, exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
C-1: Added Drag and Drop to Playground Panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drag-and-drop support: Import files and folders by dropping them directly into the workspace area
  * Visual feedback during drag operations with style changes to indicate drop zones
  * Enhanced error handling with user-friendly messages for import conflicts and validation issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->